### PR TITLE
Replace Lüften switch with button

### DIFF
--- a/components/autoterm_uart/__init__.py
+++ b/components/autoterm_uart/__init__.py
@@ -4,15 +4,14 @@ from esphome import const
 import esphome.components.uart as uart
 import esphome.components.sensor as sensor
 import esphome.components.text_sensor as text_sensor
-import esphome.components.switch as switch
 import esphome.components.number as number
 import esphome.components.button as button
 
-DEPENDENCIES = ["sensor", "text_sensor", "switch", "number", "button"]
+DEPENDENCIES = ["sensor", "text_sensor", "number", "button"]
 
 autoterm_ns = cg.esphome_ns.namespace("autoterm_uart")
 AutotermPowerOffButton = autoterm_ns.class_("AutotermPowerOffButton", button.Button)
-AutotermFanModeSwitch = autoterm_ns.class_("AutotermFanModeSwitch", switch.Switch)
+AutotermFanModeButton = autoterm_ns.class_("AutotermFanModeButton", button.Button)
 AutotermFanLevelNumber = autoterm_ns.class_("AutotermFanLevelNumber", number.Number)
 AutotermUART = autoterm_ns.class_("AutotermUART", cg.Component)
 
@@ -40,7 +39,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional("use_work_time"): sensor.sensor_schema(icon="mdi:timer-outline"),
 
     cv.Optional("power_off"): button.button_schema(class_=AutotermPowerOffButton, icon="mdi:power-standby"),
-    cv.Optional("fan_mode"): switch.switch_schema(class_=AutotermFanModeSwitch, icon="mdi:fan"),
+    cv.Optional("fan_mode"): button.button_schema(class_=AutotermFanModeButton, icon="mdi:fan"),
     cv.Optional("fan_level"): number.number_schema(class_=AutotermFanLevelNumber, icon="mdi:fan-speed-1"),
 
 
@@ -84,8 +83,8 @@ async def to_code(config):
         cg.add(var.set_power_off_button(btn))
 
     if "fan_mode" in config:
-        sw = await switch.new_switch(config["fan_mode"])
-        cg.add(var.set_fan_mode_switch(sw))
+        btn = await button.new_button(config["fan_mode"])
+        cg.add(var.set_fan_mode_button(btn))
 
     if "fan_level" in config:
         conf = config["fan_level"]

--- a/components/autoterm_uart/autoterm_uart.h
+++ b/components/autoterm_uart/autoterm_uart.h
@@ -3,7 +3,6 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
-#include "esphome/components/switch/switch.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/button/button.h"
 #include <vector>
@@ -30,15 +29,15 @@ class AutotermPowerOffButton : public button::Button {
  
 
 // ===================
-// Custom Switch Class
+// Custom Button Class (Lüften)
 // ===================
-class AutotermFanModeSwitch : public switch_::Switch {
+class AutotermFanModeButton : public button::Button {
  public:
   AutotermUART *parent_{nullptr};
   void setup_parent(AutotermUART *p) { parent_ = p; }
 
  protected:
-  void write_state(bool state) override;  // Implementierung folgt unten
+  void press_action() override;
 };
 
 // ===================
@@ -81,7 +80,7 @@ class AutotermUART : public Component {
 
   // Steuerobjekte
   AutotermPowerOffButton *power_off_button_{nullptr};
-  AutotermFanModeSwitch *fan_mode_switch_{nullptr};
+  AutotermFanModeButton *fan_mode_button_{nullptr};
   AutotermFanLevelNumber *fan_level_number_{nullptr};
 
   void send_power_off();
@@ -111,9 +110,9 @@ class AutotermUART : public Component {
     power_off_button_ = b;
     if (b) b->setup_parent(this);
   }
-  void set_fan_mode_switch(AutotermFanModeSwitch *s) {
-    fan_mode_switch_ = s;
-    if (s) s->setup_parent(this);
+  void set_fan_mode_button(AutotermFanModeButton *b) {
+    fan_mode_button_ = b;
+    if (b) b->setup_parent(this);
   }
   void set_fan_level_number(AutotermFanLevelNumber *n) {
     fan_level_number_ = n;
@@ -193,12 +192,12 @@ public:
 // Methodenimplementierungen
 // ===================
 
-// Switch gedrückt → Fan Mode senden
-void AutotermFanModeSwitch::write_state(bool state) {
-  publish_state(state);
+// Button gedrückt → Lüften aktivieren
+void AutotermFanModeButton::press_action() {
+  ESP_LOGI("autoterm_uart", "Fan Mode button pressed");
   if (parent_) {
     int level = parent_->fan_level_number_ ? (int)parent_->fan_level_number_->state : 8;
-    parent_->send_fan_mode(state, level);
+    parent_->send_fan_mode(true, level);
   }
 }
 


### PR DESCRIPTION
## Summary
- convert the Lüften control from a switch to a stateless button in the custom Autoterm UART component
- update the component schema so Home Assistant now exposes Lüften as a button entity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e61b231cd0832b878f37326231a571