### PR TITLE
Convert temperature source sensor to text sensor

### DIFF
--- a/components/autoterm_uart/__init__.py
+++ b/components/autoterm_uart/__init__.py
@@ -30,8 +30,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional("pump_frequency"): sensor.sensor_schema(unit_of_measurement="Hz", icon="mdi:water-pump"),
 
     cv.Optional("status_text"): text_sensor.text_sensor_schema(icon="mdi:information"),
-
-    cv.Optional("temperature_source"): sensor.sensor_schema(icon="mdi:thermometer"),
+    cv.Optional("temperature_source"): text_sensor.text_sensor_schema(icon="mdi:thermometer"),
     cv.Optional("set_temperature"): sensor.sensor_schema(unit_of_measurement="°C", icon="mdi:thermometer"),
     cv.Optional("work_time"): sensor.sensor_schema(unit_of_measurement="min", icon="mdi:clock-outline"),
     cv.Optional("power_level"): sensor.sensor_schema(icon="mdi:fan"),
@@ -63,7 +62,6 @@ async def to_code(config):
         ("fan_speed_set", "set_fan_speed_set_sensor"),
         ("fan_speed_actual", "set_fan_speed_actual_sensor"),
         ("pump_frequency", "set_pump_frequency_sensor"),
-        ("temperature_source", "set_temperature_source_sensor"),
         ("set_temperature", "set_set_temperature_sensor"),
         ("work_time", "set_work_time_sensor"),
         ("power_level", "set_power_level_sensor"),
@@ -74,9 +72,13 @@ async def to_code(config):
             sens = await sensor.new_sensor(config[key])
             cg.add(getattr(var, setter)(sens))
 
-    if "status_text" in config:
-        txt = await text_sensor.new_text_sensor(config["status_text"])
-        cg.add(var.set_status_text_sensor(txt))
+    for key, setter in [
+        ("status_text", "set_status_text_sensor"),
+        ("temperature_source", "set_temperature_source_text_sensor"),
+    ]:
+        if key in config:
+            txt = await text_sensor.new_text_sensor(config[key])
+            cg.add(getattr(var, setter)(txt))
 
     if "power_off" in config:
         btn = await button.new_button(config["power_off"])

--- a/components/autoterm_uart/autoterm_uart.h
+++ b/components/autoterm_uart/autoterm_uart.h
@@ -69,7 +69,7 @@ class AutotermUART : public Component {
   Sensor *fan_speed_set_sensor_{nullptr};
   Sensor *fan_speed_actual_sensor_{nullptr};
   Sensor *pump_frequency_sensor_{nullptr};
-  Sensor *temperature_source_sensor_{nullptr};
+  text_sensor::TextSensor *temperature_source_text_sensor_{nullptr};
   Sensor *set_temperature_sensor_{nullptr};
   Sensor *work_time_sensor_{nullptr};
   Sensor *power_level_sensor_{nullptr};
@@ -96,7 +96,9 @@ class AutotermUART : public Component {
   void set_fan_speed_set_sensor(Sensor *s) { fan_speed_set_sensor_ = s; }
   void set_fan_speed_actual_sensor(Sensor *s) { fan_speed_actual_sensor_ = s; }
   void set_pump_frequency_sensor(Sensor *s) { pump_frequency_sensor_ = s; }
-  void set_temperature_source_sensor(Sensor *s) { temperature_source_sensor_ = s; }
+  void set_temperature_source_text_sensor(text_sensor::TextSensor *s) {
+    temperature_source_text_sensor_ = s;
+  }
   void set_set_temperature_sensor(Sensor *s) { set_temperature_sensor_ = s; }
   void set_work_time_sensor(Sensor *s) { work_time_sensor_ = s; }
   void set_power_level_sensor(Sensor *s) { power_level_sensor_ = s; }
@@ -301,7 +303,26 @@ void AutotermUART::parse_settings(const std::vector<uint8_t> &data) {
 
     if (use_work_time_sensor_) use_work_time_sensor_->publish_state(use_work_time);
     if (work_time_sensor_) work_time_sensor_->publish_state(work_time);
-    if (temperature_source_sensor_) temperature_source_sensor_->publish_state(temp_source);
+    if (temperature_source_text_sensor_) {
+      const char *temp_source_txt = "unknown";
+      switch (temp_source) {
+        case 1:
+          temp_source_txt = "internal sensor";
+          break;
+        case 2:
+          temp_source_txt = "panel sensor";
+          break;
+        case 3:
+          temp_source_txt = "external sensor";
+          break;
+        case 4:
+          temp_source_txt = "no automatic temperature control";
+          break;
+        default:
+          break;
+      }
+      temperature_source_text_sensor_->publish_state(temp_source_txt);
+    }
     if (set_temperature_sensor_) set_temperature_sensor_->publish_state(set_temp);
     if (wait_mode_sensor_) wait_mode_sensor_->publish_state(wait_mode);
     if (power_level_sensor_) power_level_sensor_->publish_state(power_level);


### PR DESCRIPTION
## Summary
- change the temperature_source configuration option to use a text sensor instead of a numeric sensor
- map the raw UART value to descriptive strings for the text sensor output
- update the code generation to wire the new text sensor into the component

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e623d80d44832bb4bbc2f75e5f8769