### PR TITLE
Convert temperature source control to select component

### DIFF
--- a/components/autoterm_uart/__init__.py
+++ b/components/autoterm_uart/__init__.py
@@ -6,9 +6,10 @@ import esphome.components.sensor as sensor
 import esphome.components.text_sensor as text_sensor
 import esphome.components.number as number
 import esphome.components.switch as switch
+import esphome.components.select as select
 import esphome.components.button as button
 
-DEPENDENCIES = ["sensor", "text_sensor", "number", "button", "switch"]
+DEPENDENCIES = ["sensor", "text_sensor", "number", "button", "switch", "select"]
 
 autoterm_ns = cg.esphome_ns.namespace("autoterm_uart")
 AutotermPowerOnButton = autoterm_ns.class_("AutotermPowerOnButton", button.Button)
@@ -18,7 +19,7 @@ AutotermFanLevelNumber = autoterm_ns.class_("AutotermFanLevelNumber", number.Num
 AutotermSetTemperatureNumber = autoterm_ns.class_("AutotermSetTemperatureNumber", number.Number)
 AutotermWorkTimeNumber = autoterm_ns.class_("AutotermWorkTimeNumber", number.Number)
 AutotermPowerLevelNumber = autoterm_ns.class_("AutotermPowerLevelNumber", number.Number)
-AutotermTemperatureSourceNumber = autoterm_ns.class_("AutotermTemperatureSourceNumber", number.Number)
+AutotermTemperatureSourceSelect = autoterm_ns.class_("AutotermTemperatureSourceSelect", select.Select)
 AutotermUseWorkTimeSwitch = autoterm_ns.class_("AutotermUseWorkTimeSwitch", switch.Switch)
 AutotermWaitModeSwitch = autoterm_ns.class_("AutotermWaitModeSwitch", switch.Switch)
 AutotermUART = autoterm_ns.class_("AutotermUART", cg.Component)
@@ -61,8 +62,8 @@ CONFIG_SCHEMA = cv.Schema({
         class_=AutotermPowerLevelNumber,
         icon="mdi:fan",
     ),
-    cv.Optional("temperature_source_control"): number.number_schema(
-        class_=AutotermTemperatureSourceNumber,
+    cv.Optional("temperature_source_control"): select.select_schema(
+        class_=AutotermTemperatureSourceSelect,
         icon="mdi:thermometer",
     ),
     cv.Optional("use_work_time_switch"): switch.switch_schema(
@@ -155,12 +156,8 @@ async def to_code(config):
         num = await number.new_number(conf, min_value=min_v, max_value=max_v, step=step_v)
         cg.add(var.set_power_level_number(num))
     if "temperature_source_control" in config:
-        conf = config["temperature_source_control"]
-        min_v = conf.get("min_value", 1)
-        max_v = conf.get("max_value", 4)
-        step_v = conf.get("step", 1)
-        num = await number.new_number(conf, min_value=min_v, max_value=max_v, step=step_v)
-        cg.add(var.set_temperature_source_number(num))
+        sel = await select.new_select(config["temperature_source_control"])
+        cg.add(var.set_temperature_source_select(sel))
     if "use_work_time_switch" in config:
         sw = await switch.new_switch(config["use_work_time_switch"])
         cg.add(var.set_use_work_time_switch(sw))

--- a/components/autoterm_uart/autoterm_uart.h
+++ b/components/autoterm_uart/autoterm_uart.h
@@ -6,6 +6,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/components/button/button.h"
 #include "esphome/components/switch/switch.h"
+#include "esphome/components/select/select.h"
 #include <vector>
 #include <functional>
 #include <string>
@@ -91,13 +92,15 @@ class AutotermPowerLevelNumber : public number::Number {
   void control(float value) override;
 };
 
-class AutotermTemperatureSourceNumber : public number::Number {
+class AutotermTemperatureSourceSelect : public select::Select {
  public:
   AutotermUART *parent_{nullptr};
   void setup_parent(AutotermUART *p) { parent_ = p; }
 
+  select::SelectTraits get_traits() override;
+
  protected:
-  void control(float value) override;
+  void control(const std::string &value) override;
 };
 
 class AutotermUseWorkTimeSwitch : public esphome::switch_::Switch {
@@ -152,7 +155,7 @@ class AutotermUART : public Component {
   AutotermSetTemperatureNumber *set_temperature_number_{nullptr};
   AutotermWorkTimeNumber *work_time_number_{nullptr};
   AutotermPowerLevelNumber *power_level_number_{nullptr};
-  AutotermTemperatureSourceNumber *temperature_source_number_{nullptr};
+  AutotermTemperatureSourceSelect *temperature_source_select_{nullptr};
   AutotermUseWorkTimeSwitch *use_work_time_switch_{nullptr};
   AutotermWaitModeSwitch *wait_mode_switch_{nullptr};
 
@@ -220,9 +223,9 @@ class AutotermUART : public Component {
     power_level_number_ = n;
     if (n) n->setup_parent(this);
   }
-  void set_temperature_source_number(AutotermTemperatureSourceNumber *n) {
-    temperature_source_number_ = n;
-    if (n) n->setup_parent(this);
+  void set_temperature_source_select(AutotermTemperatureSourceSelect *s) {
+    temperature_source_select_ = s;
+    if (s) s->setup_parent(this);
   }
   void set_use_work_time_switch(AutotermUseWorkTimeSwitch *s) {
     use_work_time_switch_ = s;
@@ -315,6 +318,7 @@ public:
   void publish_settings_(const Settings &settings);
   void update_settings_(const std::function<void(Settings &)> &updater);
   std::string temperature_source_to_string(uint8_t value) const;
+  uint8_t temperature_source_from_string(const std::string &value) const;
 };
 
 // ===================
@@ -356,9 +360,27 @@ void AutotermPowerLevelNumber::control(float value) {
   if (parent_) parent_->set_power_level(static_cast<uint8_t>(value));
 }
 
-void AutotermTemperatureSourceNumber::control(float value) {
+void AutotermTemperatureSourceSelect::control(const std::string &value) {
+  if (parent_ == nullptr) {
+    ESP_LOGW("autoterm_uart", "Temperature source select has no parent");
+    return;
+  }
+
+  uint8_t numeric_value = parent_->temperature_source_from_string(value);
+  if (numeric_value == 0) {
+    ESP_LOGW("autoterm_uart", "Unknown temperature source option: %s", value.c_str());
+    return;
+  }
+
   publish_state(value);
-  if (parent_) parent_->set_temperature_source(static_cast<uint8_t>(value));
+  parent_->set_temperature_source(numeric_value);
+}
+
+select::SelectTraits AutotermTemperatureSourceSelect::get_traits() {
+  select::SelectTraits traits;
+  traits.set_options({"internal sensor", "panel sensor", "external sensor",
+                      "no automatic temperature control"});
+  return traits;
 }
 
 void AutotermUseWorkTimeSwitch::write_state(bool state) {
@@ -590,8 +612,8 @@ void AutotermUART::publish_settings_(const Settings &settings) {
   std::string temp_source_txt = temperature_source_to_string(settings.temperature_source);
   if (temperature_source_text_sensor_) temperature_source_text_sensor_->publish_state(temp_source_txt);
 
-  if (temperature_source_number_)
-    temperature_source_number_->publish_state(settings.temperature_source);
+  if (temperature_source_select_)
+    temperature_source_select_->publish_state(temp_source_txt);
   if (set_temperature_number_)
     set_temperature_number_->publish_state(settings.set_temperature);
   if (work_time_number_)
@@ -626,6 +648,18 @@ std::string AutotermUART::temperature_source_to_string(uint8_t value) const {
     default:
       return "unknown";
   }
+}
+
+uint8_t AutotermUART::temperature_source_from_string(const std::string &value) const {
+  if (value == "internal sensor")
+    return 1;
+  if (value == "panel sensor")
+    return 2;
+  if (value == "external sensor")
+    return 3;
+  if (value == "no automatic temperature control")
+    return 4;
+  return 0;
 }
 
 void AutotermPowerOffButton::press_action() {


### PR DESCRIPTION
## Summary
- replace the temperature source number control with a select entity that exposes the four sensor modes
- update the Autoterm UART component to publish and handle temperature source changes via descriptive strings

## Testing
- `python3 -m compileall components/autoterm_uart/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68e662f5c9fc832ba7c5b7b4f570df41