### PR TITLE
Fix custom select traits override for ESPHome update

### DIFF
--- a/components/autoterm_uart/autoterm_uart.h
+++ b/components/autoterm_uart/autoterm_uart.h
@@ -97,7 +97,7 @@ class AutotermTemperatureSourceSelect : public select::Select {
   AutotermUART *parent_{nullptr};
   void setup_parent(AutotermUART *p) { parent_ = p; }
 
-  select::SelectTraits get_traits() override;
+  select::SelectTraits traits() override;
 
  protected:
   void control(const std::string &value) override;
@@ -359,6 +359,13 @@ void AutotermWorkTimeNumber::control(float value) {
 void AutotermPowerLevelNumber::control(float value) {
   publish_state(value);
   if (parent_) parent_->set_power_level(static_cast<uint8_t>(value));
+}
+
+select::SelectTraits AutotermTemperatureSourceSelect::traits() {
+  select::SelectTraits traits;
+  traits.set_options({"internal sensor", "panel sensor", "external sensor",
+                      "no automatic temperature control"});
+  return traits;
 }
 
 void AutotermTemperatureSourceSelect::control(const std::string &value) {

--- a/components/autoterm_uart/autoterm_uart.h
+++ b/components/autoterm_uart/autoterm_uart.h
@@ -95,9 +95,11 @@ class AutotermPowerLevelNumber : public number::Number {
 class AutotermTemperatureSourceSelect : public select::Select {
  public:
   AutotermUART *parent_{nullptr};
+  AutotermTemperatureSourceSelect() {
+    this->traits.set_options({"internal sensor", "panel sensor", "external sensor",
+                              "no automatic temperature control"});
+  }
   void setup_parent(AutotermUART *p) { parent_ = p; }
-
-  select::SelectTraits traits() override;
 
  protected:
   void control(const std::string &value) override;
@@ -359,13 +361,6 @@ void AutotermWorkTimeNumber::control(float value) {
 void AutotermPowerLevelNumber::control(float value) {
   publish_state(value);
   if (parent_) parent_->set_power_level(static_cast<uint8_t>(value));
-}
-
-select::SelectTraits AutotermTemperatureSourceSelect::traits() {
-  select::SelectTraits traits;
-  traits.set_options({"internal sensor", "panel sensor", "external sensor",
-                      "no automatic temperature control"});
-  return traits;
 }
 
 void AutotermTemperatureSourceSelect::control(const std::string &value) {


### PR DESCRIPTION
## Summary
- update the Autoterm temperature source select to use the current Select API
- define the available temperature source options through the traits override

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e66a62dd80832b910c0f6368dcc035