### PR TITLE
Use configured power level when triggering fan mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ und stellt alle Werte als Sensoren, Schalter, Buttons und Nummern in Home Assist
 |:--|:--|
 | 🔍 **Statusauswertung** | Liest regelmäßig Heizungstemperatur, Spannung, interne/externe Sensorwerte, Lüfterdrehzahl, Pumpenfrequenz, Betriebsstatus |
 | 🧭 **Settings** | Liest aktuelle Einstellungen (Temperaturquelle, Solltemperatur, Arbeitszeit, Leistungsstufe, etc.) |
-| 🌀 **Lüftersteuerung** | Aktiviert den Lüftermodus („only fan“) und ändert die Lüfterstufe (0–9) |
+| 🌀 **Lüftersteuerung** | Aktiviert den Lüftermodus („only fan“) und nutzt die aktuell konfigurierte Leistungsstufe |
 | ⛔ **Ausschalten** | Schaltet Heizung oder Lüfter komplett aus (`0x03`) |
 | 🧾 **Protokoll-CRC** | CRC16 (Modbus) Validierung sämtlicher Frames |
 | 🪄 **Bridge-Funktion** | UART-Forwarding zwischen Display ↔ Heizung, ESP „snifft“ passiv mit |
@@ -93,11 +93,12 @@ autoterm-air2d/
 | `sensor.autoterm_heater_temperature` | Heizungstemperatur |
 | `sensor.autoterm_internal_temperature` | Interner Temperatursensor |
 | `sensor.autoterm_external_temperature` | Externer Temperatursensor |
-| `sensor.autoterm_fan_rpm_set` | Soll-Drehzahl |
-| `sensor.autoterm_fan_rpm_actual` | Ist-Drehzahl |
-| `sensor.autoterm_pump_frequency` | Pumpenfrequenz |
-| `sensor.autoterm_status` | Statuscode (z. B. 3.0) |
+| `sensor.autoterm_fan_rpm_set` | Soll-Drehzahl *(Diagnostic Entity)* |
+| `sensor.autoterm_fan_rpm_actual` | Ist-Drehzahl *(Diagnostic Entity)* |
+| `sensor.autoterm_pump_frequency` | Pumpenfrequenz *(Diagnostic Entity)* |
+| `sensor.autoterm_status` | Statuscode (z. B. 3.0) *(Diagnostic Entity)* |
 | `text_sensor.autoterm_status_text` | Statusbeschreibung (z. B. „heating“) |
+| `text_sensor.autoterm_temperature_source` | Temperaturquelle *(Diagnostic Entity)* |
 
 ---
 
@@ -109,6 +110,7 @@ autoterm-air2d/
 | `number.autoterm_luefterstufe` | Number | Lüfterstufe 0–9 |
 | `button.autoterm_ausschalten` | Button | Heizung/Lüfter ausschalten (`0x03`) |
 | *(optional)* `button.autoterm_starten` | Button | Heizung starten (`0x01`) |
+| `button.autoterm_lueften` | Button | Lüften mit aktueller Leistungsstufe starten |
 
 ---
 

--- a/air2d.yaml
+++ b/air2d.yaml
@@ -94,8 +94,6 @@ autoterm_uart:
 
   fan_mode:
     name: "Autoterm Lüften"
-  fan_level:
-    name: "Autoterm Lüfterstufe"
 
   set_temperature_control:
     name: "Autoterm Solltemperatur"

--- a/components/autoterm_uart/__init__.py
+++ b/components/autoterm_uart/__init__.py
@@ -39,13 +39,31 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional("external_temp"): sensor.sensor_schema(unit_of_measurement="°C", icon="mdi:thermometer"),
     cv.Optional("heater_temp"): sensor.sensor_schema(unit_of_measurement="°C", icon="mdi:thermometer"),
     cv.Optional("voltage"): sensor.sensor_schema(unit_of_measurement="V", icon="mdi:flash"),
-    cv.Optional("status"): sensor.sensor_schema(icon="mdi:information"),
-    cv.Optional("fan_speed_set"): sensor.sensor_schema(unit_of_measurement="rpm", icon="mdi:fan"),
-    cv.Optional("fan_speed_actual"): sensor.sensor_schema(unit_of_measurement="rpm", icon="mdi:fan"),
-    cv.Optional("pump_frequency"): sensor.sensor_schema(unit_of_measurement="Hz", icon="mdi:water-pump"),
+    cv.Optional("status"): sensor.sensor_schema(
+        icon="mdi:information",
+        entity_category=const.ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    cv.Optional("fan_speed_set"): sensor.sensor_schema(
+        unit_of_measurement="rpm",
+        icon="mdi:fan",
+        entity_category=const.ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    cv.Optional("fan_speed_actual"): sensor.sensor_schema(
+        unit_of_measurement="rpm",
+        icon="mdi:fan",
+        entity_category=const.ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    cv.Optional("pump_frequency"): sensor.sensor_schema(
+        unit_of_measurement="Hz",
+        icon="mdi:water-pump",
+        entity_category=const.ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
 
     cv.Optional("status_text"): text_sensor.text_sensor_schema(icon="mdi:information"),
-    cv.Optional("temperature_source"): text_sensor.text_sensor_schema(icon="mdi:thermometer"),
+    cv.Optional("temperature_source"): text_sensor.text_sensor_schema(
+        icon="mdi:thermometer",
+        entity_category=const.ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
     cv.Optional("set_temperature"): sensor.sensor_schema(unit_of_measurement="°C", icon="mdi:thermometer"),
     cv.Optional("work_time"): sensor.sensor_schema(unit_of_measurement="min", icon="mdi:clock-outline"),
     cv.Optional("power_level"): sensor.sensor_schema(icon="mdi:fan"),

--- a/components/autoterm_uart/__init__.py
+++ b/components/autoterm_uart/__init__.py
@@ -15,7 +15,6 @@ autoterm_ns = cg.esphome_ns.namespace("autoterm_uart")
 AutotermPowerOnButton = autoterm_ns.class_("AutotermPowerOnButton", button.Button)
 AutotermPowerOffButton = autoterm_ns.class_("AutotermPowerOffButton", button.Button)
 AutotermFanModeButton = autoterm_ns.class_("AutotermFanModeButton", button.Button)
-AutotermFanLevelNumber = autoterm_ns.class_("AutotermFanLevelNumber", number.Number)
 AutotermSetTemperatureNumber = autoterm_ns.class_("AutotermSetTemperatureNumber", number.Number)
 AutotermWorkTimeNumber = autoterm_ns.class_("AutotermWorkTimeNumber", number.Number)
 AutotermPowerLevelNumber = autoterm_ns.class_("AutotermPowerLevelNumber", number.Number)
@@ -56,7 +55,6 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional("power_on"): button.button_schema(class_=AutotermPowerOnButton, icon="mdi:power"),
     cv.Optional("power_off"): button.button_schema(class_=AutotermPowerOffButton, icon="mdi:power-standby"),
     cv.Optional("fan_mode"): button.button_schema(class_=AutotermFanModeButton, icon="mdi:fan"),
-    cv.Optional("fan_level"): number.number_schema(class_=AutotermFanLevelNumber, icon="mdi:fan-speed-1"),
     cv.Optional("set_temperature_control"): number.number_schema(
         class_=AutotermSetTemperatureNumber,
         icon="mdi:thermometer",
@@ -133,14 +131,6 @@ async def to_code(config):
         btn = await button.new_button(config["fan_mode"])
         cg.add(var.set_fan_mode_button(btn))
 
-    if "fan_level" in config:
-        conf = config["fan_level"]
-        # Standardwerte definieren, falls nicht im YAML angegeben
-        min_v = conf.get("min_value", 0)
-        max_v = conf.get("max_value", 9)
-        step_v = conf.get("step", 1)
-        num = await number.new_number(conf, min_value=min_v, max_value=max_v, step=step_v)
-        cg.add(var.set_fan_level_number(num))
     if "set_temperature_control" in config:
         conf = config["set_temperature_control"]
         min_v = conf.get("min_value", 0)

--- a/components/autoterm_uart/autoterm_uart.h
+++ b/components/autoterm_uart/autoterm_uart.h
@@ -56,15 +56,6 @@ class AutotermFanModeButton : public button::Button {
 // ===================
 // Custom Number Class
 // ===================
-class AutotermFanLevelNumber : public number::Number {
- public:
-  AutotermUART *parent_{nullptr};
-  void setup_parent(AutotermUART *p) { parent_ = p; }
-
- protected:
-  void control(float value) override;  // Implementierung folgt unten
-};
-
 class AutotermSetTemperatureNumber : public number::Number {
  public:
   AutotermUART *parent_{nullptr};
@@ -153,7 +144,6 @@ class AutotermUART : public Component {
   AutotermPowerOnButton *power_on_button_{nullptr};
   AutotermPowerOffButton *power_off_button_{nullptr};
   AutotermFanModeButton *fan_mode_button_{nullptr};
-  AutotermFanLevelNumber *fan_level_number_{nullptr};
   AutotermSetTemperatureNumber *set_temperature_number_{nullptr};
   AutotermWorkTimeNumber *work_time_number_{nullptr};
   AutotermPowerLevelNumber *power_level_number_{nullptr};
@@ -208,10 +198,6 @@ class AutotermUART : public Component {
   void set_fan_mode_button(AutotermFanModeButton *b) {
     fan_mode_button_ = b;
     if (b) b->setup_parent(this);
-  }
-  void set_fan_level_number(AutotermFanLevelNumber *n) {
-    fan_level_number_ = n;
-    if (n) n->setup_parent(this);
   }
   void set_set_temperature_number(AutotermSetTemperatureNumber *n) {
     set_temperature_number_ = n;
@@ -337,15 +323,9 @@ void AutotermPowerOnButton::press_action() {
 void AutotermFanModeButton::press_action() {
   ESP_LOGI("autoterm_uart", "Fan Mode button pressed");
   if (parent_) {
-    int level = parent_->fan_level_number_ ? (int)parent_->fan_level_number_->state : 8;
+    uint8_t level = parent_->settings_.power_level;
     parent_->send_fan_mode(true, level);
   }
-}
-
-// Number geändert → Level senden
-void AutotermFanLevelNumber::control(float value) {
-  publish_state(value);
-  if (parent_) parent_->send_fan_mode(true, (int)value);
 }
 
 void AutotermSetTemperatureNumber::control(float value) {


### PR DESCRIPTION
## Summary
- send the configured power level value when the fan mode button is pressed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e66f1d9be8832ba2fc786c2ab74402