### PR TITLE
Use current settings payload for power on command

### DIFF
--- a/components/autoterm_uart/autoterm_uart.h
+++ b/components/autoterm_uart/autoterm_uart.h
@@ -1005,7 +1005,17 @@ void AutotermUART::send_power_on() {
   if (!this->uart_heater_) return;
 
   const uint8_t header[] = {0xAA, 0x03, 0x06, 0x00, 0x01};
-  const uint8_t payload[] = {0x01, 0x00, 0x04, 0x10, 0x00, 0x08};
+  Settings payload_settings = settings_;
+  if (!settings_valid_) {
+    payload_settings = Settings{};
+  }
+
+  const uint8_t payload[] = {payload_settings.use_work_time,
+                             payload_settings.work_time,
+                             payload_settings.temperature_source,
+                             payload_settings.set_temperature,
+                             payload_settings.wait_mode,
+                             payload_settings.power_level};
 
 
   std::vector<uint8_t> frame(header, header + 5);


### PR DESCRIPTION
## Summary
- reuse the stored settings when constructing the power on payload
- fall back to default settings values if the current settings are not yet known

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6c6245c94832ba774791f2ed7c311