### PR TITLE
Remove heater control buttons from configuration

### DIFF
--- a/air2d.yaml
+++ b/air2d.yaml
@@ -90,15 +90,6 @@ autoterm_uart:
     name: "Pump Frequency"
     unit_of_measurement: "Hz"
 
-  power_off:
-    name: "Ausschalten"
-  power_on:
-    name: "Einschalten"
-
-  fan_mode:
-    name: "Lüften"
-
-
   set_temperature_control:
     name: "Solltemperatur"
   work_time_control:


### PR DESCRIPTION
## Summary
- remove the power on/off and fan mode button entities from the Autoterm UART example configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7cd498f30832babecf89b0718eec8